### PR TITLE
RubyLouvre/object-defineproperty-ie8#1 webpack 编译后，后不一定是 value

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ if (!supportsDescriptors) {
     if (origDefineProperty && a.nodeType == 1) {
       return origDefineProperty(a, b, c);
     } else {
-      a[b] = c.value;
+      a[b] = c.value || (c.get && c.get());
     }
   };
 }


### PR DESCRIPTION
可以看下编译后代码

```js

/******/ 	// define getter function for harmony exports
/******/ 	__webpack_require__.d = function(exports, name, getter) {
/******/ 		if(!__webpack_require__.o(exports, name)) {
/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
/******/ 		}
/******/ 	};

// getDefaultExport function for compatibility with non-harmony modules
/******/ 	__webpack_require__.n = function(module) {
/******/ 		var getter = module && module.__esModule ?
/******/ 			function getDefault() { return module['default']; } :
/******/ 			function getModuleExports() { return module; };
/******/ 		__webpack_require__.d(getter, 'a', getter);
/******/ 		return getter;
/******/ 	};

```